### PR TITLE
Added SimulateHTTPLatency

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,13 @@ client.GetQueue(url).OnEmptyQueue = func() {
 See the
 [documentation for Queue](https://godoc.org/github.com/elliotchance/mocksqs#Queue)
 for more information.
+
+# Simulating HTTP Latency
+
+SimulateHTTPLatency when enabled will add a sleep between 20 and 100
+milliseconds to each call that would otherwise need to make a HTTP request with
+a real SQS client:
+
+```go
+client.SimulateHTTPLatency = true
+```

--- a/delete_message.go
+++ b/delete_message.go
@@ -8,6 +8,8 @@ import (
 
 // DeleteMessage is fully supported.
 func (client *SQS) DeleteMessage(input *sqs.DeleteMessageInput) (*sqs.DeleteMessageOutput, error) {
+	client.httpRequest()
+
 	client.Lock()
 	defer client.Unlock()
 
@@ -37,6 +39,8 @@ func (client *SQS) deleteMessage(input *sqs.DeleteMessageInput) (*sqs.DeleteMess
 
 // DeleteMessageBatch is fully supported.
 func (client *SQS) DeleteMessageBatch(input *sqs.DeleteMessageBatchInput) (*sqs.DeleteMessageBatchOutput, error) {
+	client.httpRequest()
+
 	client.Lock()
 	defer client.Unlock()
 

--- a/receive.go
+++ b/receive.go
@@ -21,6 +21,8 @@ import (
 // - ReceiveMessageInput.WaitTimeSeconds
 //
 func (client *SQS) ReceiveMessage(input *sqs.ReceiveMessageInput) (*sqs.ReceiveMessageOutput, error) {
+	client.httpRequest()
+
 	client.Lock()
 	defer client.Unlock()
 

--- a/send.go
+++ b/send.go
@@ -32,6 +32,8 @@ import (
 // - SendMessageOutput.SequenceNumber
 //
 func (client *SQS) SendMessage(input *sqs.SendMessageInput) (*sqs.SendMessageOutput, error) {
+	client.httpRequest()
+
 	client.Lock()
 	defer client.Unlock()
 

--- a/sqs.go
+++ b/sqs.go
@@ -3,12 +3,19 @@ package mocksqs
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/sqs"
+	"math/rand"
 	"sync"
+	"time"
 )
 
 type SQS struct {
 	sync.RWMutex
 	queues sync.Map // map[string]*Queue
+
+	// SimulateHTTPLatency when enabled will add a sleep between 20 and 100
+	// milliseconds to each call that would otherwise need to make a HTTP
+	// request with a real SQS client.
+	SimulateHTTPLatency bool
 }
 
 // New creates a new SQS service that contains no queues.
@@ -46,4 +53,11 @@ func (client *SQS) GetQueue(queueURL string) *Queue {
 	}
 
 	return queue.(*Queue)
+}
+
+func (client *SQS) httpRequest() {
+	if client.SimulateHTTPLatency {
+		ms := 10 + rand.Int() % 90
+		time.Sleep(time.Duration(ms) * time.Millisecond)
+	}
 }

--- a/visibility.go
+++ b/visibility.go
@@ -22,6 +22,8 @@ func (client *SQS) changeMessageVisibility(input *sqs.ChangeMessageVisibilityInp
 }
 
 func (client *SQS) ChangeMessageVisibility(input *sqs.ChangeMessageVisibilityInput) (*sqs.ChangeMessageVisibilityOutput, error) {
+	client.httpRequest()
+
 	client.Lock()
 	defer client.Unlock()
 


### PR DESCRIPTION
SimulateHTTPLatency when enabled will add a sleep between 20 and 100 milliseconds to each call that would otherwise need to make a HTTP request with a real SQS client

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/mocksqs/2)
<!-- Reviewable:end -->
