### PR TITLE
Improves resilience to reduced time precision in message visibility

### DIFF
--- a/receive.go
+++ b/receive.go
@@ -35,7 +35,8 @@ func (client *SQS) ReceiveMessage(input *sqs.ReceiveMessageInput) (*sqs.ReceiveM
 
 		for el := queue.messages.Front(); el != nil; el = el.Next() {
 			message := el.Value.(*Message)
-			if time.Now().After(message.VisibleAfter) {
+			t := time.Now()
+			if t.After(message.VisibleAfter) || t == message.VisibleAfter {
 				_, _ = client.changeMessageVisibility(&sqs.ChangeMessageVisibilityInput{
 					QueueUrl:          input.QueueUrl,
 					ReceiptHandle:     message.ReceiptHandle,


### PR DESCRIPTION
This change treats messages as deliverable when `VisibleAfter` is exactly equal to the current time.

This is not a common problem under normal production circumstances where the chance of nanosecond collision is low and the consequences are trivial. However, there are two instances where this becomes important:

1. Windows (and possibly other environments) have poor sub-millisecond clock precision. 
2. Some sandbox environments (like play.golang.org) have fixed clocks that don't tick forward.

Consider the following code:
```go
package main

import "time"

func main() {
	println(time.Now().UnixNano())
	println(time.Now().UnixNano())
	println(time.Now().UnixNano())
}
```

On linux:
```
> go run ../time.go
1576134435779233324
1576134435779244506
1576134435779248859
```
On windows: 
```
$ go run ../time.go
1576134363205402100
1576134363205402100
1576134363205402100
```
On [play.golang.org](https://play.golang.org/p/fPAzEvFd_oe):
```
1257894000000000000
1257894000000000000
1257894000000000000

Program exited.
```

See #3 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/mocksqs/4)
<!-- Reviewable:end -->
